### PR TITLE
fix spinup stuff

### DIFF
--- a/modules/asusf_installer_forms/asusf_installer_forms.install
+++ b/modules/asusf_installer_forms/asusf_installer_forms.install
@@ -21,13 +21,16 @@ function asusf_installer_forms_install() {
   if (!$config->get('installer_forms_completed')) {
     // Place the custom block in a region.
     $theme = \Drupal::theme()->getActiveTheme()->getName();
+    $profile = \Drupal::installProfile();
+    $region = $profile === 'webspark' ? 'header' : ($profile === 'asudrupal' ? 'hero' : 'content');
+    $weight = $profile === 'webspark' ? 10 : -1;
     $block = Block::create([
       'id' => 'multi_step_form_instance',
       'plugin' => 'site_config_multi_step_form_block',
-      'region' => 'header',
+      'region' => $region,
       'theme' => $theme,
       'visibility' => [],
-      'weight' => 10,
+      'weight' => $weight,
       'status' => 1,
       'label' => 'Multi-step Setup Form',
     ]);

--- a/modules/asusf_installer_forms/asusf_installer_forms.module
+++ b/modules/asusf_installer_forms/asusf_installer_forms.module
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for asusf_installer_forms module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function asusf_installer_forms_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // get the active configuration.
+  $config = \Drupal::configFactory()->getEditable('asusf_installer_forms.settings');
+  if (!$config->get('installer_forms_completed')) {
+    $initially_disallowed_forms = [
+      'user_admin_permissions',
+      'views_form_user_admin_people_page_1',
+      'user_admin_settings',
+      'system_modules',
+      'system_themes_admin_form',
+      'user_admin_roles_form',
+      'role_settings',
+      'views_form_content_page_1',
+      'views_form_media_media_page_list',
+      'media_type_add_form',
+      'block_content_type_add_form',
+      'block_admin_display_form',
+      'node_type_add_form',
+      'system_theme_settings',
+      'system_themes_admin_form',
+      'update_manager_update_form',
+      'system_modules_uninstall',
+      'cas_settings',
+      'config_admin_import_form',
+      'config_import_form',
+      'config_single_import_form',
+      'config_export_form',
+      'config_single_export_form',
+      'user_register_form',
+      'bulk_add_cas_users',
+      'update_manager_update_form',
+      'update_settings',
+      'view_add_form',
+      'view_edit_form',
+      'taxonomy_vocabulary_form',
+      'paragraphs_type_add_form',
+    ];
+    $initially_disallowed_form_ids = [
+      'views-exposed-form-authmap-page'
+    ];
+    if (in_array($form_id, $initially_disallowed_forms) || in_array($form['#id'], $initially_disallowed_form_ids)) {
+      $form['#access'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function asusf_installer_forms_preprocess_page(&$variables) {
+  // get the active configuration.
+  $config = \Drupal::configFactory()->getEditable('asusf_installer_forms.settings');
+  if (!$config->get('installer_forms_completed')) {
+    $paths = [
+      '/admin/appearance',
+      '/admin/appearance/update',
+    ];
+    if (in_array(\Drupal::service('path.current')->getPath(), $paths, TRUE)) {
+      $variables['page']['content']['#access'] = FALSE;
+    }
+  }
+}

--- a/modules/asusf_installer_forms/css/installer-form.css
+++ b/modules/asusf_installer_forms/css/installer-form.css
@@ -8,3 +8,20 @@
   max-width: 1200px;
   margin: 4rem auto 0;
 }
+
+.asudrupal .border {
+  border: 1px solid #dee2e6 !important;
+}
+
+.asudrupal .py-4 {
+  padding-bottom: 2rem !important;
+}
+.asudrupal .px-3 {
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important;
+}
+
+.asudrupal .my-4 {
+  margin-bottom: 2rem !important;
+  margin-top: 2rem !important;
+}


### PR DESCRIPTION
This PR is in conjunction with MRs on stack1 and stack3:
- https://code.acquia.com/ArizonaBoardofRegentsSiteFactoryACSFSites/asufactory1/-/merge_requests/489
- https://code.acquia.com/asufactory3/asufactory3/-/merge_requests/90

Basically, this makes site spinups as secure as possible. It waits to add the admin toolbar until after the initial config form has been filled out. Upon form submission, it installs the `admin_toolbar` and `toolbar` modules and grants appropriate permissions. It also uninstalls the `asusf_installer_forms` module.

In addition to removing the admin toolbar from the profiles and adding it here, I have added some `form_alters` and `preprocess_hooks` that basically render the site inert until the configuration form is completed. It is now impossible to do anything of consequence on the site until after the initial config form has been completed.

I have moved the placement of the form block in Stack 3 so that it avoids the jiggling bug that we were seeing.

Finally, I have added some styles for the asudrupal profile, since it doesn't use bootstrap, so that the form will look a little more similar to the one in webspark.