### PR TITLE
update allowed modules and permissions

### DIFF
--- a/asu_governance.install
+++ b/asu_governance.install
@@ -200,3 +200,49 @@ function asu_governance_update_10000() {
   }
 
 }
+
+/**
+ * Update allowable modules and permissions.
+ */
+function asu_governance_update_10001() {
+
+  $newModules = [
+    'asset_injector',
+    'siteimprove',
+    'masquerade',
+    'smtp',
+    'metatag_verification',
+    'feeds',
+    'better_exposed_filters',
+    'mailsystem',
+    'views_data_export',
+    'feeds_tamper',
+    'metatag_open_graph',
+    'honeypot',
+    'views_bulk_operations',
+    'metatag_views',
+  ];
+
+  $newPermissions = [
+    'switch users',
+  ];
+
+  $config = \Drupal::service('config.factory')->getEditable('asu_governance.settings');
+
+  $moduleList = $config->get('allowable_modules', []);
+  foreach ($newModules as $module) {
+    if (!in_array($module, $moduleList, TRUE)) {
+      $moduleList[] = $module;
+    }
+  }
+  $config->set('allowable_modules', $moduleList);
+
+  $permissionsBlacklist = $config->get('permissions_blacklist', []);
+  if (!in_array('switch users', $permissionsBlacklist, TRUE)) {
+    $permissionsBlacklist[] = 'switch users';
+    $config->set('permissions_blacklist', $permissionsBlacklist);
+  }
+
+  $config->save();
+
+}

--- a/config/install/asu_governance.settings.yml
+++ b/config/install/asu_governance.settings.yml
@@ -31,6 +31,20 @@ allowable_modules:
   - webspark_webdir
   - captcha
   - editoria11y
+  - asset_injector
+  - siteimprove
+  - masquerade
+  - smtp
+  - metatag_verification
+  - feeds
+  - better_exposed_filters
+  - mailsystem
+  - views_data_export
+  - feeds_tamper
+  - metatag_open_graph
+  - honeypot
+  - views_bulk_operations
+  - metatag_views
 allowable_themes:
   - claro
   - radix
@@ -50,3 +64,4 @@ permissions_blacklist:
   - masquerade as super user
   - masquerade as any user
   - masquerade as administrator
+  - switch users


### PR DESCRIPTION
This allows a list of modules to be enabled by the Site Builder and also adds "switch users" to the blacklisted permissions list.

**Steps to test:**

On an existing site:
1. Run `drush updb`
2. Check to see if the modules appear as unselected in the ASU Modules page (/admin/config/system/asu/modules)
3. Enable one of the modules (for example, Asset Injector)
4. Go to /admin/people/permissions/site_builder and verify that the Site Builder role has access to any permissions defined by the module you enabled.
5. Go to /admin/config/system/asu/governance-settings and verify that the modules and permission are included in the proper fields

On a new spinup:
1. Spin up a new site
2. Log into the site as an administrator
3. Do steps 2 and 5 from the existing site steps