### PR TITLE
fix install errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,13 @@
     "name": "asuwebplatforms/asu_governance",
     "description": "A module to lock down ASU Drupal sites for Acquia Site Factory",
     "type": "drupal-module",
-    "license": "MIT"
+    "license": "MIT",
+    "require": {
+        "drush/drush": "^13.6",
+        "drupal/cas": "^2.3",
+        "drupal/purge": "^3.6",
+        "drupal/acquia_purge": "^1.5",
+        "drupal/simple_sitemap": "^4.2",
+        "drupal/admin_toolbar": "^3.5"
+    }
 }

--- a/modules/asusf_installer_forms/asusf_installer_forms.info.yml
+++ b/modules/asusf_installer_forms/asusf_installer_forms.info.yml
@@ -3,4 +3,5 @@ type: module
 description: 'Contains the subforms for each step of the installation form'
 core_version_requirement: ^10 || ^11
 dependencies:
+  - drupal:simple_sitemap
   - drupal:cas

--- a/modules/asusf_installer_forms/src/Form/MultiStepAjaxForm.php
+++ b/modules/asusf_installer_forms/src/Form/MultiStepAjaxForm.php
@@ -275,9 +275,6 @@ class MultiStepAjaxForm extends FormBase {
     if (is_callable($handler)) {
       $handler($form_state);
     }
-    elseif (is_string($handler)) {
-      $handler($form_state);
-    }
   }
 
   /**


### PR DESCRIPTION
I'm not sure how I feel about this PR. It fixes the modules so that they can be installed on a vanilla drupal site without any profile or other intervention. I mostly did this so that I could more easily develop and test the module locally, because this allows me to install/uninstall it on vanilla Drupal more easily. We have solved for the issues this PR deals with via our custom profiles, but, I figured it might be worth it to include the changes in the repo.