### PR TITLE
Add stack 5 support in ddev and drush tools

### DIFF
--- a/.ddev/commands/web/asusf:aliases
+++ b/.ddev/commands/web/asusf:aliases
@@ -1,4 +1,6 @@
 #!/bin/bash
+#ddev-generated
+
 ##
 ## NOTE: This is a copy of the asusf:aliases command in the webspark stacks. It is only included here
 ## to enable local development and testing. The command needs to be installed in whatever project uses
@@ -133,7 +135,7 @@ function get_site_list() {
   fi
 }
 
-options=("Webspark Stack" "The College Stack" "Drupal Stack" "Webspark Stack (Drupal 9)")
+options=("Webspark Stack" "The College Stack" "Drupal Stack" "Webspark Stack (Drupal 9)" "Fulton Engineering Stack")
 # Display the menu with indented numbers
 echo -e "${YELLOW}Please choose a site factory stack:${NC}"
 for i in "${!options[@]}"; do

--- a/src/Drush/Commands/_common.sh
+++ b/src/Drush/Commands/_common.sh
@@ -33,6 +33,7 @@ declare -A STACKS=(
   [1]="Webspark Stack"
   [3]="Drupal Stack"
   [4]="Webspark Stack [Drupal 9]"
+  [5]="Fulton Engineering Stack"
 )
 
 # Maps stack number → Drush alias prefix.
@@ -42,6 +43,7 @@ declare -A STACK_ALIASES=(
   [1]="@asufactory1.01"
   [3]="@asufactory3.03"
   [4]="@asufactory4.04"
+  [5]="@asufactory5.05"
 )
 
 # Maps stack number → alias file path (relative to project root).
@@ -49,6 +51,7 @@ declare -A STACK_ALIAS_FILES=(
   [1]="drush/sites/asufactory1.site.yml"
   [3]="drush/sites/asufactory3.site.yml"
   [4]="drush/sites/asufactory4.site.yml"
+  [5]="drush/sites/asufactory5.site.yml"
 )
 
 # Maps stack number → acli download instructions (application name and number).
@@ -56,6 +59,7 @@ declare -A STACK_ALIAS_DOWNLOAD_HINTS=(
   [1]="Webspark Stack"
   [3]="ASU Drupal Stack"
   [4]="Webspark Stack Drupal 9"
+  [5]="Fulton Engineering Stack"
 )
 
 # Maps stack number → Acquia Cloud application UUID.
@@ -65,6 +69,7 @@ declare -A STACK_APP_UUIDS=(
   [1]="ed6ba37d-8d64-4a45-8d89-78f9460cf550"
   [3]="6c63152a-3c87-4295-8999-8c3f6b03ae30"
   [4]="e64e5765-54f4-4b6e-9b12-8c4071f2067e"
+  [5]="ee1a8f14-65ee-4392-9a1d-3a75f3fe82c8"
 )
 
 # Define available roles to manage


### PR DESCRIPTION
This is pretty straightforward. It will allow the asu_governance drush commands to target stack 5 sites for adding and managing user roles. It also adds something to the ddev site spinup script that is apparently a best-practice, but doesn't make much difference either way. \*shrug\*