### PR TITLE
map repo and set defaults on new install

### DIFF
--- a/.ddev/commands/host/add-admin
+++ b/.ddev/commands/host/add-admin
@@ -58,7 +58,7 @@ function addadmin() {
   fi
   ddev drush ucrt "$1";
   ddev drush urol administrator "$1";
-  ddev launch $(ddev drush uli --name="$1" --no-browser)
+  ddev launch "$(ddev drush uli --name="$1" --no-browser)"
 }
 
 addadmin "$@"

--- a/.ddev/commands/host/add-admin
+++ b/.ddev/commands/host/add-admin
@@ -58,6 +58,7 @@ function addadmin() {
   fi
   ddev drush ucrt "$1";
   ddev drush urol administrator "$1";
+  ddev launch $(ddev drush uli --name="$1" --no-browser)
 }
 
 addadmin "$@"

--- a/.ddev/commands/host/setup-local
+++ b/.ddev/commands/host/setup-local
@@ -45,7 +45,7 @@ function setuplocal() {
   ddev symlink-project;
   ddev drush si -y;
   ddev drush en asusf_installer_forms -y;
-  ddev launch "$(ddev drush uli)";
+  ddev launch "$(ddev drush uli --no-browser)";
 }
 
 setuplocal

--- a/asu_governance.install
+++ b/asu_governance.install
@@ -5,6 +5,7 @@
  * Install, update and uninstall functions for the asu_governance module.
  */
 
+use Drupal\asu_governance\Services\GovernanceConfigResolver;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Symfony\Component\Yaml\Yaml;
@@ -361,14 +362,6 @@ function asu_governance_update_10005() {
 function _asu_governance_get_repo_mapping(): array {
   return [
     'repo_labels' => [
-      'aaexpert' => 'Ask an Expert',
-      'asuapp1' => 'ASU CMS (Homepage)',
-      'asuapp2' => 'ASU iSearch',
-      'asuapp3' => 'Financial Aid',
-      'asuapp4' => 'Sun Devil Athletics',
-      'asuapp6' => 'Thunderbird',
-      'asunews' => 'ASU News',
-      'asutest1' => 'ASU Test1',
       'asufactory1' => 'Webspark Stack',
       'asufactory2' => 'The College Stack',
       'asufactory3' => 'ASU Drupal Stack',
@@ -433,17 +426,17 @@ function _asu_governance_apply_preset_on_install(): void {
   }
 
   ['key' => $presetKey, 'label' => $presetLabel] = $resolved;
-  $presetConfigName = 'asu_governance.settings.env_' . $presetKey;
 
-  // Try to load defaults from the preset YAML file.
-  $module_extension_list = \Drupal::service('extension.list.module');
-  $modulePath = $module_extension_list->getPath('asu_governance');
-  $yamlFile = DRUPAL_ROOT . '/' . $modulePath . '/config/install/' . $presetConfigName . '.yml';
+  // Load preset data via the config resolver (DB-first, YAML fallback with
+  // error handling) instead of manually reading from disk.
+  /** @var \Drupal\asu_governance\Services\GovernanceConfigResolver $configResolver */
+  $configResolver = \Drupal::service('asu_governance.config_resolver');
+  $presetData = $configResolver->loadPresetData($presetKey);
 
-  if (!file_exists($yamlFile)) {
+  if ($presetData === NULL) {
     \Drupal::logger('asu_governance')->notice(
-      'No preset YAML file found for "@key" (looked for @file). Using base config.',
-      ['@key' => $presetKey, '@file' => $yamlFile]
+      'No preset data found for "@key". Using base config.',
+      ['@key' => $presetKey]
     );
     // Still set the active preset key so the form knows which preset is selected.
     \Drupal::configFactory()->getEditable('asu_governance.settings')
@@ -452,21 +445,24 @@ function _asu_governance_apply_preset_on_install(): void {
     return;
   }
 
-  $presetData = Yaml::parse(file_get_contents($yamlFile));
-
   // Apply the preset defaults to the main governance settings.
   $config = \Drupal::configFactory()->getEditable('asu_governance.settings');
-  $config->set('allowable_modules', $presetData['allowable_modules'] ?? []);
-  $config->set('allowable_themes', $presetData['allowable_themes'] ?? []);
-  $config->set('permissions_blacklist', $presetData['permissions_blacklist'] ?? []);
-  $config->set('allow_config_access', $presetData['allow_config_access'] ?? FALSE);
-  $config->set('allow_roles_perms_admin', $presetData['allow_roles_perms_admin'] ?? FALSE);
-  $config->set('permissions_users', $presetData['permissions_users'] ?? []);
+  $fieldDefaults = [
+    'allowable_modules' => [],
+    'allowable_themes' => [],
+    'permissions_blacklist' => [],
+    'allow_config_access' => FALSE,
+    'allow_roles_perms_admin' => FALSE,
+    'permissions_users' => [],
+  ];
+  foreach (GovernanceConfigResolver::PRESET_FIELDS as $field) {
+    $config->set($field, $presetData[$field] ?? ($fieldDefaults[$field] ?? NULL));
+  }
   $config->set('active_environment_preset', $presetKey);
   $config->save();
 
   \Drupal::logger('asu_governance')->notice(
-    'Applied environment preset "@key" ("@label") from YAML defaults.',
+    'Applied environment preset "@key" ("@label") from resolved config.',
     ['@key' => $presetKey, '@label' => $presetLabel]
   );
 }

--- a/asu_governance.install
+++ b/asu_governance.install
@@ -34,7 +34,10 @@ function asu_governance_install() {
     return;
   }
 
-  // Get the current theme
+  // Detect the repository and apply the matching environment preset defaults.
+  _asu_governance_apply_preset_on_install();
+
+  // Ensure the current theme is in the allowable themes list.
   $currentTheme = \Drupal::service('theme_handler')->getDefault();
   $config = \Drupal::configFactory()->getEditable('asu_governance.settings');
   $allowableThemes = $config->get('allowable_themes') ?? [];
@@ -75,7 +78,7 @@ function asu_governance_install() {
   // Add base permissions to the Content Editor role.
   $modulePermissionHandler->addBasePermissions('content_editor', 'BASE_CE_PERMISSIONS');
 
-  // Get the list of allowable modules.
+  // Get the list of allowable modules (now populated from the preset).
   $allowableModules = \Drupal::config('asu_governance.settings')->get('allowable_modules');
   // Update the Site Builder role's permissions.
   $modulePermissionHandler->addSiteBuilderModulePermissions($allowableModules);
@@ -305,56 +308,14 @@ function asu_governance_update_10004() {
  * the GovernanceSettingsForm remembers the selection.
  */
 function asu_governance_update_10005() {
-  // Repository-to-label mapping.
-  $repoMapping = [
-    'aaexpert' => 'Ask an Expert',
-    'asuapp1' => 'ASU CMS (Homepage)',
-    'asuapp2' => 'ASU iSearch',
-    'asuapp3' => 'Financial Aid',
-    'asuapp4' => 'Sun Devil Athletics',
-    'asuapp6' => 'Thunderbird',
-    'asunews' => 'ASU News',
-    'asutest1' => 'ASU Test1',
-    'asufactory1' => 'Webspark stack',
-    'asufactory2' => 'The College stack',
-    'asufactory3' => 'ASU Drupal stack',
-    'asufactory4' => 'Webspark stack (Drupal 9)',
-    'asufactory5' => 'Fulton Schools of Engineering stack',
-    'asufactory6' => 'Knowledge Enterprise stack',
-  ];
-
-  // Maps repository names to existing preset keys (from YAML files).
-  // If a repo matches one of these, we reuse that preset key.
-  $repoToPresetKey = [
-    'asufactory1' => 'stack1',
-    'asufactory2' => 'stack2',
-    'asufactory3' => 'stack3',
-    'asufactory4' => 'stack4',
-    'asufactory5' => 'stack5',
-    'asufactory6' => 'stack6',
-  ];
-
-  // Determine the repository name.
-  $repoName = _asu_governance_get_repo_name();
-  if (empty($repoName)) {
+  $resolved = _asu_governance_resolve_preset();
+  if ($resolved === NULL) {
     \Drupal::logger('asu_governance')->warning('Could not determine repository name during update 10005. Skipping preset mapping.');
     return;
   }
 
-  // Determine the preset key and label.
-  if (isset($repoToPresetKey[$repoName])) {
-    // This repo maps to an existing YAML preset.
-    $presetKey = $repoToPresetKey[$repoName];
-  }
-  else {
-    // Generate a machine-safe key from the repo name.
-    $presetKey = preg_replace('/[^a-z0-9_]/', '_', strtolower($repoName));
-    $presetKey = preg_replace('/_+/', '_', trim($presetKey, '_'));
-  }
-
-  $presetLabel = $repoMapping[$repoName] ?? $repoName;
-  $configPrefix = 'asu_governance.settings.env_';
-  $presetConfigName = $configPrefix . $presetKey;
+  ['key' => $presetKey, 'label' => $presetLabel] = $resolved;
+  $presetConfigName = 'asu_governance.settings.env_' . $presetKey;
 
   // Load the current active governance settings from the database.
   $mainConfig = \Drupal::configFactory()->get('asu_governance.settings');
@@ -385,7 +346,128 @@ function asu_governance_update_10005() {
 
   \Drupal::logger('asu_governance')->notice(
     'Mapped repository "@repo" to environment preset "@key" ("@label").',
-    ['@repo' => $repoName, '@key' => $presetKey, '@label' => $presetLabel]
+    ['@repo' => _asu_governance_get_repo_name(), '@key' => $presetKey, '@label' => $presetLabel]
+  );
+}
+
+/**
+ * Returns the repository-to-label mapping and repo-to-preset-key mapping.
+ *
+ * @return array
+ *   An associative array with two keys:
+ *   - 'repo_labels': Maps repository names to human-readable labels.
+ *   - 'repo_preset_keys': Maps repository names to preset keys (from YAML).
+ */
+function _asu_governance_get_repo_mapping(): array {
+  return [
+    'repo_labels' => [
+      'aaexpert' => 'Ask an Expert',
+      'asuapp1' => 'ASU CMS (Homepage)',
+      'asuapp2' => 'ASU iSearch',
+      'asuapp3' => 'Financial Aid',
+      'asuapp4' => 'Sun Devil Athletics',
+      'asuapp6' => 'Thunderbird',
+      'asunews' => 'ASU News',
+      'asutest1' => 'ASU Test1',
+      'asufactory1' => 'Webspark Stack',
+      'asufactory2' => 'The College Stack',
+      'asufactory3' => 'ASU Drupal Stack',
+      'asufactory4' => 'Webspark stack (Drupal 9)',
+      'asufactory5' => 'Fulton Engineering Stack',
+    ],
+    'repo_preset_keys' => [
+      'asufactory1' => 'stack1',
+      'asufactory2' => 'stack2',
+      'asufactory3' => 'stack3',
+      'asufactory4' => 'stack4',
+      'asufactory5' => 'stack5',
+    ],
+  ];
+}
+
+/**
+ * Resolve the current environment to a preset key and label.
+ *
+ * @return array|null
+ *   An associative array with 'key' and 'label', or NULL if the repository
+ *   cannot be determined.
+ */
+function _asu_governance_resolve_preset(): ?array {
+  $repoName = _asu_governance_get_repo_name();
+  if (empty($repoName)) {
+    return NULL;
+  }
+
+  $mapping = _asu_governance_get_repo_mapping();
+  $repoLabels = $mapping['repo_labels'];
+  $repoPresetKeys = $mapping['repo_preset_keys'];
+
+  // Determine the preset key.
+  if (isset($repoPresetKeys[$repoName])) {
+    $presetKey = $repoPresetKeys[$repoName];
+  }
+  else {
+    // Generate a machine-safe key from the repo name.
+    $presetKey = preg_replace('/[^a-z0-9_]/', '_', strtolower($repoName));
+    $presetKey = preg_replace('/_+/', '_', trim($presetKey, '_'));
+  }
+
+  $presetLabel = $repoLabels[$repoName] ?? $repoName;
+
+  return ['key' => $presetKey, 'label' => $presetLabel];
+}
+
+/**
+ * Detect the environment preset and apply its YAML defaults on fresh install.
+ *
+ * On a new install the database config is empty, so we load the matching
+ * preset YAML file and populate asu_governance.settings with its defaults.
+ * If no matching preset file is found, the install proceeds with the base
+ * (empty) config and the admin can configure it later via the settings form.
+ */
+function _asu_governance_apply_preset_on_install(): void {
+  $resolved = _asu_governance_resolve_preset();
+  if ($resolved === NULL) {
+    \Drupal::logger('asu_governance')->notice('Could not determine repository name during install. Preset must be configured manually.');
+    return;
+  }
+
+  ['key' => $presetKey, 'label' => $presetLabel] = $resolved;
+  $presetConfigName = 'asu_governance.settings.env_' . $presetKey;
+
+  // Try to load defaults from the preset YAML file.
+  $module_extension_list = \Drupal::service('extension.list.module');
+  $modulePath = $module_extension_list->getPath('asu_governance');
+  $yamlFile = DRUPAL_ROOT . '/' . $modulePath . '/config/install/' . $presetConfigName . '.yml';
+
+  if (!file_exists($yamlFile)) {
+    \Drupal::logger('asu_governance')->notice(
+      'No preset YAML file found for "@key" (looked for @file). Using base config.',
+      ['@key' => $presetKey, '@file' => $yamlFile]
+    );
+    // Still set the active preset key so the form knows which preset is selected.
+    \Drupal::configFactory()->getEditable('asu_governance.settings')
+      ->set('active_environment_preset', $presetKey)
+      ->save();
+    return;
+  }
+
+  $presetData = Yaml::parse(file_get_contents($yamlFile));
+
+  // Apply the preset defaults to the main governance settings.
+  $config = \Drupal::configFactory()->getEditable('asu_governance.settings');
+  $config->set('allowable_modules', $presetData['allowable_modules'] ?? []);
+  $config->set('allowable_themes', $presetData['allowable_themes'] ?? []);
+  $config->set('permissions_blacklist', $presetData['permissions_blacklist'] ?? []);
+  $config->set('allow_config_access', $presetData['allow_config_access'] ?? FALSE);
+  $config->set('allow_roles_perms_admin', $presetData['allow_roles_perms_admin'] ?? FALSE);
+  $config->set('permissions_users', $presetData['permissions_users'] ?? []);
+  $config->set('active_environment_preset', $presetKey);
+  $config->save();
+
+  \Drupal::logger('asu_governance')->notice(
+    'Applied environment preset "@key" ("@label") from YAML defaults.',
+    ['@key' => $presetKey, '@label' => $presetLabel]
   );
 }
 


### PR DESCRIPTION
This PR fills a gap on new installs, where it detects which stack the site is on and maps it to the appropriate default governance configs for modules and themes, etc. It extracts the logic from the hook update and puts it in a helper function, and then references that function in both the hook_install and the existing hook_update.

**QA steps**
This is a little challenging to QA. But, what you can do is pull the module down locally, copy it entirely, and then paste it into the appropriate place in an existing project (like Stack 3 or Stack 5). Then, you can run a new site install in the default DDEV environment by running `ddev drush si`. This will wipe out your default ddev database and environment (which we don't use in the stack ddev setup). Then, it will install Webspark. After it installs, log in and go to `/admin/config/system/asu/governance-settings` and see if the appropriate default item was selected in the "Please indicate your stack or website" dropdown field. If it has loaded all of the presets, this should pass.
If you don't have a stack setup locally, we can zoom and do it together.